### PR TITLE
issue-12: Add signaloid.yaml to specify the default core and minimum core

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ The output of this code should have the following format:
 <output distribution> <run time in microseconds>
 ```
 
+> [!NOTE]
+> For the most accurate results, make sure to use the Jupiter microarchitecture on Signaloid.
+
+
 Larger experimental suites, such as running repeated experiments using multiple different representation sizes can be done via the [Signaloid Cloud Compute Engine API](https://docs.signaloid.io/docs/api/). Additional tools and instructions on how to do so for this repository will be added in the future.
 
 ### Run on Traditional Hardware

--- a/signaloid.yaml
+++ b/signaloid.yaml
@@ -1,0 +1,6 @@
+MinimumCore:
+    Class: "C0Pro"
+    Microarchitecture: "Jupiter"
+    CorrelationTracking: "Disable"
+    MemorySize: 2000000
+    Precision: 128


### PR DESCRIPTION
PR Highlights:
- Didn't add default core since that isn't possible.
- Added minimum core to be Jupiter with 128 representation size and 2000000 memory size.
- Added description in README recommending use of Jupiter microarchitecture.